### PR TITLE
[Refactor] 프로필 수정 이벤트 발행을 AFTER_COMMIT 방식으로 개선

### DIFF
--- a/src/main/java/com/finlearn/userservice/application/ProfileService.java
+++ b/src/main/java/com/finlearn/userservice/application/ProfileService.java
@@ -3,13 +3,13 @@ package com.finlearn.userservice.application;
 import com.finlearn.common.exception.ConflictException;
 import com.finlearn.common.exception.NotFoundException;
 import com.finlearn.userservice.domain.Profile;
-import com.finlearn.userservice.infrastructure.kafka.UserEventProducer;
-import com.finlearn.userservice.infrastructure.kafka.event.UserProfileUpdatedEvent;
+import com.finlearn.userservice.domain.user.event.ProfileUpdatedEvent;
 import com.finlearn.userservice.infrastructure.persistence.ProfileJpaRepository;
 import com.finlearn.userservice.presentation.dto.request.UpdateProfileRequest;
 import com.finlearn.userservice.presentation.dto.response.ProfileResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
@@ -21,7 +21,7 @@ import java.util.UUID;
 public class ProfileService {
 
     private final ProfileJpaRepository profileJpaRepository;
-    private final UserEventProducer userEventProducer;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 내 프로필 조회
@@ -73,7 +73,7 @@ public class ProfileService {
     }
 
     private void publishProfileUpdatedEvent(Profile profile) {
-        userEventProducer.publishUserProfileUpdated(new UserProfileUpdatedEvent(
+        eventPublisher.publishEvent(new ProfileUpdatedEvent(
                 profile.getUserId(),
                 profile.getNickname(),
                 profile.getProfileImage()

--- a/src/main/java/com/finlearn/userservice/domain/user/event/ProfileUpdatedEvent.java
+++ b/src/main/java/com/finlearn/userservice/domain/user/event/ProfileUpdatedEvent.java
@@ -1,0 +1,10 @@
+package com.finlearn.userservice.domain.user.event;
+
+import java.util.UUID;
+
+public record ProfileUpdatedEvent(
+        UUID userId,
+        String nickname,
+        String profileImage
+) {
+}

--- a/src/main/java/com/finlearn/userservice/infrastructure/event/ProfileUpdatedEventListener.java
+++ b/src/main/java/com/finlearn/userservice/infrastructure/event/ProfileUpdatedEventListener.java
@@ -1,8 +1,8 @@
 package com.finlearn.userservice.infrastructure.event;
 
-import com.finlearn.userservice.domain.user.event.UserCreatedEvent;
+import com.finlearn.userservice.domain.user.event.ProfileUpdatedEvent;
 import com.finlearn.userservice.infrastructure.kafka.UserEventProducer;
-import com.finlearn.userservice.infrastructure.kafka.event.UserRegisteredEvent;
+import com.finlearn.userservice.infrastructure.kafka.event.UserProfileUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -12,15 +12,17 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class UserCreatedEventListener {
+public class ProfileUpdatedEventListener {
 
     private final UserEventProducer userEventProducer;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleUserCreatedEvent(UserCreatedEvent event) {
-        log.info("UserCreatedEvent 수신 - userId: {}, email: {}", event.userId(), event.email());
+    public void handleProfileUpdatedEvent(ProfileUpdatedEvent event) {
+        log.info("ProfileUpdatedEvent 수신 - userId: {}", event.userId());
         try {
-            userEventProducer.publishUserRegistered(new UserRegisteredEvent(event.userId(), event.email()));
+            userEventProducer.publishUserProfileUpdated(
+                    new UserProfileUpdatedEvent(event.userId(), event.nickname(), event.profileImage())
+            );
         } catch (Exception e) {
             log.error("Kafka 이벤트 발행 실패 - userId: {}, error: {}", event.userId(), e.getMessage());
         }

--- a/src/main/java/com/finlearn/userservice/infrastructure/kafka/UserEventProducer.java
+++ b/src/main/java/com/finlearn/userservice/infrastructure/kafka/UserEventProducer.java
@@ -1,8 +1,10 @@
 package com.finlearn.userservice.infrastructure.kafka;
 
 import com.finlearn.userservice.infrastructure.kafka.event.UserProfileUpdatedEvent;
+import com.finlearn.userservice.infrastructure.kafka.event.UserRegisteredEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
@@ -14,7 +16,24 @@ public class UserEventProducer {
 
     private static final String TOPIC_USER_PROFILE_UPDATED = "user.profile-updated";
 
+    @Value("${kafka.topics.user.registered:finlearn-user-registered}")
+    private String topicUserRegistered;
+
     private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    // 회원가입 시 발행
+    public void publishUserRegistered(UserRegisteredEvent event) {
+        log.info("[Kafka] UserRegistered 이벤트 발행: userId={}, email={}", event.getUserId(), event.getEmail());
+        kafkaTemplate.send(topicUserRegistered, event.getUserId().toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("[Kafka] UserRegistered 이벤트 발행 실패: {}", ex.getMessage());
+                    } else {
+                        log.info("[Kafka] UserRegistered 이벤트 발행 완료: topic={}, offset={}",
+                                topicUserRegistered, result.getRecordMetadata().offset());
+                    }
+                });
+    }
 
     // 닉네임 또는 프로필 이미지 변경 시 발행
     public void publishUserProfileUpdated(UserProfileUpdatedEvent event) {

--- a/src/main/java/com/finlearn/userservice/infrastructure/kafka/event/UserRegisteredEvent.java
+++ b/src/main/java/com/finlearn/userservice/infrastructure/kafka/event/UserRegisteredEvent.java
@@ -1,0 +1,16 @@
+package com.finlearn.userservice.infrastructure.kafka.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRegisteredEvent {
+
+    private UUID userId;
+    private String email;
+}

--- a/src/main/java/com/finlearn/userservice/presentation/user/controller/AuthController.java
+++ b/src/main/java/com/finlearn/userservice/presentation/user/controller/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 public class AuthController {
 
     private final UserService userService;

--- a/src/main/java/com/finlearn/userservice/presentation/user/controller/UserController.java
+++ b/src/main/java/com/finlearn/userservice/presentation/user/controller/UserController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 public class UserController {
 
     private final UserService userService;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    properties:
+      security.protocol: PLAINTEXT
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      retries: 3
+    consumer:
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      enable-auto-commit: false
+      auto-offset-reset: earliest
+    listener:
+      ack-mode: MANUAL_IMMEDIATE
+      concurrency: 1
+      missing-topics-fatal: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
     driver-class-name: org.postgresql.Driver
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
 
 eureka:
   instance:


### PR DESCRIPTION
## 🌱 설명

- 프로필 수정 로직에서 Kafka producer를 직접 호출하던 구조를 도메인 이벤트 기반 구조로 개선했습니다.
- `ProfileService`는 Kafka 발행 구현체에 직접 의존하지 않고, `ApplicationEventPublisher`를 통해 `ProfileUpdatedEvent`를 발행하도록 변경했습니다.
- `ProfileUpdatedEventListener`에서 `@TransactionalEventListener(AFTER_COMMIT)`를 사용하여 DB 커밋 완료 이후 Kafka 이벤트가 발행되도록 수정했습니다.
- 이를 통해 트랜잭션 롤백 시에도 Kafka 이벤트가 먼저 발행되는 데이터 정합성 문제를 방지했습니다.

## 📌 관련 이슈

- close #10 

---

## 💻 커밋 유형

- [ ] feat : 새로운 기능 추가
- [ ] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [x] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가

---

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature/refactor 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일을 확인했나요?
- [x] 트랜잭션 커밋 이후 이벤트가 발행되는 구조인지 확인했나요?
- [x] 롤백 상황에서 Kafka 이벤트가 발행되지 않는지 확인했나요?
- [x] 기존 회원 생성 이벤트 발행 패턴과 일관성을 확인했나요?