### PR TITLE
[Feat] UserCreatedEvent 리스너 비동기 처리 적용

### DIFF
--- a/src/main/java/com/finlearn/userservice/UserServiceApplication.java
+++ b/src/main/java/com/finlearn/userservice/UserServiceApplication.java
@@ -2,7 +2,9 @@ package com.finlearn.userservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class UserServiceApplication {
 

--- a/src/main/java/com/finlearn/userservice/infrastructure/event/UserCreatedEventListener.java
+++ b/src/main/java/com/finlearn/userservice/infrastructure/event/UserCreatedEventListener.java
@@ -5,6 +5,7 @@ import com.finlearn.userservice.infrastructure.kafka.UserEventProducer;
 import com.finlearn.userservice.infrastructure.kafka.event.UserRegisteredEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -16,6 +17,7 @@ public class UserCreatedEventListener {
 
     private final UserEventProducer userEventProducer;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleUserCreatedEvent(UserCreatedEvent event) {
         log.info("UserCreatedEvent 수신 - userId: {}, email: {}", event.userId(), event.email());


### PR DESCRIPTION
## 🌱 설명
> 이 PR에서 어떤 작업을 했는지 간략하게 설명해주세요.
- user-service에서 Spring 비동기 처리를 활성화하기 위해 `@EnableAsync`를 추가했습니다.
- `UserCreatedEventListener`에 `@Async`를 적용하여 회원 생성 이벤트 처리 로직이 비동기로 실행되도록 변경했습니다.
- 기존 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`는 유지하여 회원 생성 트랜잭션 커밋 이후 Kafka 이벤트가 발행되도록 했습니다.

## 📌 관련 이슈
> 이 PR과 연관된 이슈 번호를 작성해주세요. (이슈 없으면 생략 가능)
- close #12 

## 💻 커밋 유형
> 해당하는 항목에 `x`를 채워주세요.
- [x] feat : 새로운 기능 추가
- [ ] fix : 버그 수정
- [ ] !hotfix : 급하게 치명적인 버그 수정
- [ ] refactor : 리팩토링
- [ ] chore : 빌드 설정, 의존성 업데이트 등
- [ ] docs : 문서 수정
- [ ] comment : 필요한 주석 추가 및 변경
- [ ] rename : 파일 또는 폴더 명을 수정하거나 옮기는 작업
- [ ] remove : 파일을 삭제하는 작업
- [ ] test : 테스트 코드, 리팩토링 테스트 코드 추가


## 📝 체크리스트
> PR 올리기 전에 아래 항목을 확인해주세요.
- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했습니다.
- [x] 제가 작성한 코드를 스스로 리뷰했습니다.
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?


## 📚 추가 설명
> 리뷰어가 참고해야 할 내용이 있다면 자유롭게 작성해주세요. (선택)
- 기존에는 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`만 사용하여 회원 생성 트랜잭션 커밋 이후 이벤트를 처리했습니다.
- 이번 변경으로 `@Async`를 함께 적용하여 Kafka 이벤트 발행이 별도 스레드에서 비동기로 처리되도록 개선했습니다.
- 이를 통해 Kafka 발행 지연이 발생하더라도 회원가입 요청 처리 스레드가 오래 점유되는 상황을 줄일 수 있습니다.
- `@Async` 활성화를 위해 `UserServiceApplication`에 `@EnableAsync`를 추가했습니다.
- 리뷰 시 회원가입 이후 `UserCreatedEvent`가 정상적으로 처리되고 Kafka 이벤트가 발행되는지 확인 부탁드립니다.